### PR TITLE
feat (media_entity_image): fix update to v8.x-1.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -375,7 +375,7 @@
         "drupal/linkit": "5.0-beta7",
         "drupal/media_entity": "2.0.0-beta2",
         "drupal/media_entity_document": "1.x-dev",
-        "drupal/media_entity_image": "1.3",
+        "drupal/media_entity_image": "^1.3",
         "drupal/media_entity_slideshow": "2.0-alpha1",
         "drupal/menu_block": "1.4.0",
         "drupal/menu_breadcrumb": "1.5",


### PR DESCRIPTION
drupal/media_entity_image version needs to change to ^1.3 to fix the following composer error:
For more information, see link: https://www.drupal.org/project/media_entity_image/releases/8.x-1.3 
```
[Composer\DependencyResolver\SolverProblemsException]
  Problem 1
      - drupalwxt/wxt 2.1.8 requires drupal/media_entity_image 1.3 -> no matching package found.
      - open-data/od dev-8.x-2.x-test requires drupalwxt/wxt 2.1.8 -> satisfiable by drupalwxt/wxt[2.1.8].
      - Installation request for open-data/od dev-8.x-2.x-test -> satisfiable by open-data/od[dev-8.x-2.x-test].

  Potential causes:
   - A typo in the package name
   - The package is not available in a stable-enough version according to your minimum-stability setting
     see <https://getcomposer.org/doc/04-schema.md#minimum-stability> for more details.
   - It's a private package and you forgot to add a custom repository to find it

  Read <https://getcomposer.org/doc/articles/troubleshooting.md> for further common problems.
```