### PR TITLE
update drupal core to 8.6.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -217,7 +217,7 @@
         "drupal/ckeditor_codemirror": "2.1",
         "drupal/config_rewrite": "1.1",
         "drupal/config_update": "1.6",
-        "drupal/core": "8.6.5",
+        "drupal/core": "8.6.6",
         "drupal/diff": "1.0-rc2",
         "drupal/entity_reference_revisions": "1.6",
         "drupal/features": "^3.0",


### PR DESCRIPTION
Following Drupal core security updates:
 - Drupal core - Critical - Third Party Libraries - SA-CORE-2019-001 (https://www.drupal.org/sa-core-2019-001) 
 - Drupal core - Critical - Arbitrary PHP code execution - SA-CORE-2019-002 (https://www.drupal.org/sa-core-2019-002)