### PR TITLE
fix(password_policy): remove patch for issue #2975694 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -247,10 +247,6 @@
                 "Allow the previewing of nodes with panelizer":
                 "https://www.drupal.org/files/issues/2019-05-17/panelizer-node-previews-2750491-7.patch"
             },
-            "drupal/password_policy": {
-                "Character types in character plugin not translatable":
-                "https://www.drupal.org/files/issues/2020-03-17/Password-Policy-constraints-summary-character-types-labels-not-translatable-2975694-16.patch"
-            },
             "drupal/s3fs": {
                 "Enter drupal/s3fs patch #2986407 description here":
                 "https://www.drupal.org/files/issues/2018-07-17/s3fs-2986407-save-memory-2.patch",


### PR DESCRIPTION
Password policy [patch ](https://www.drupal.org/files/issues/2020-03-17/Password-Policy-constraints-summary-character-types-labels-not-translatable-2975694-16.patch )for issue [#2975694](https://www.drupal.org/project/password_policy/issues/2975694) was committed in [03ec42b7f8d50b44ddad3362af23b0b51973cb25](https://git.drupalcode.org/project/password_policy/-/commit/03ec42b7f8d50b44ddad3362af23b0b51973cb25).