### PR TITLE
feat(migrate): Support creating multiple sections using the `wxt_layout_plugin_id` migration plugin

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
 
     - uses: statcan/actions/composer@master
       with:
-        args: require drupalwxt/wxt:4.2.x-dev#${GITHUB_SHA} --working-dir=./site-wxt
+        args: require drupalwxt/wxt:4.2.x-dev#${{ github.sha }} --working-dir=./site-wxt
 
     - name: Build out the Drupal infrastructure
       run: |

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,7 +19,7 @@ jobs:
 
     - uses: statcan/actions/composer@master
       with:
-        args: require drupalwxt/wxt:dev-${GITHUB_HEAD_REF}#${GITHUB_SHA} --working-dir=./site-wxt
+        args: require ${{ github.event.pull_request.head.repo.full_name }}:dev-${{ github.event.pull_request.head.ref }}#${{ github.event.pull_request.head.sha }} --working-dir=./site-wxt
 
     - name: Build out the Drupal infrastructure
       run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,10 +23,10 @@
   - GC Subway not working correctly in Intranet theme [#3253829](https://www.drupal.org/project/wxt/issues/3253829)
   - Issues with Insert from Media Library [#3246714](https://www.drupal.org/project/wxt/issues/3246714)
   - Add new `route:<separator>` for menu items [#3236799](https://www.drupal.org/project/wxt/issues/3236799)
+- Update `wxt_layout_plugin_id` migration process plugin to support
+  creating multiple sections.
 
 Upgrade path:
-
-> Note: To Be Written
 
 - Update your codebase:
   - `composer update`
@@ -43,7 +43,37 @@ Upgrade path:
   - `drush cache:rebuild`
   - `drush update:wxt`
 
-**Note:** To Be Written.
+**Note**: The data structure expected by the `wxt_layout_plugin_id`
+migration plugin has been updated to support multiple sections.
+
+The current format only created one section:
+
+```yaml
+layout_id: 'layoutid'
+layout_settings: {}
+components: []
+```
+
+The new format is a top-level `sections` array, which supports multiple entries:
+
+```yaml
+# Same behaviour as previous format
+sections:
+- layout_id: 'layoutid'
+  layout_settings: {}
+  components: []
+```
+
+```yaml
+# New format which support multiple sections
+sections:
+- layout_id: 'layoutid1'
+  layout_settings: {}
+  components: []
+- layout_id: 'layoutid2'
+  layout_settings: {}
+  components: []
+```
 
 ## v4.1.2
 

--- a/modules/custom/wxt_ext/wxt_ext_migration/config/install/migrate_plus.migration.gcweb_node_landing_page.yml
+++ b/modules/custom/wxt_ext/wxt_ext_migration/config/install/migrate_plus.migration.gcweb_node_landing_page.yml
@@ -20,137 +20,18 @@ source:
           description: '[node:summary]'
           keywords: 'Canada.ca, Open Government, Open Government Canada, Canada Open Government, Canada Open'
       layout:
-        layout_id: 'wxt_homepage'
-        layout_settings:
-          layout:
-            wrapper: div
-            classes: {}
-            add_layout_class: 1
-            attributes: ''
-          regions:
-            top:
-              wrapper: div
-              classes: {}
-              add_region_classes: 1
-              attributes: ''
-            top_left:
-              wrapper: div
-              classes:
-                col-md-6: col-md-8
-              add_region_classes: 1
-              attributes: class|mrgn-tp-md
-            top_right:
-              wrapper: div
-              classes:
-                col-md-6: col-md-4
-              add_region_classes: 1
-              attributes: class|mrgn-tp-xl
-            middle:
-              wrapper: div
-              classes:
-                col-sm-12: col-sm-12
-              add_region_classes: 1
-              attributes: ''
-            bottom_left:
-              wrapper: div
-              classes:
-                col-sm-6: col-sm-6
-              add_region_classes: 1
-              attributes: ''
-            bottom_right:
-              wrapper: div
-              classes:
-                col-sm-6: col-sm-6
-              add_region_classes: 1
-              attributes: ''
-            bottom:
-              wrapper: div
-              classes:
-                col-sm-12: col-sm-12
-              add_region_classes: 1
-              attributes: class|mrgn-tp-lg
-        components:
-          -
-            region: top
-            configuration:
-              id: 'block_content:homepage_block_1'
-              label: Canada
-              provider: 'block_content'
-              label_display: 0
-              view_mode: default
-              context_mapping: {}
-            additional: {  }
-            weight: 1
-          -
-            region: top
-            configuration:
-              id: 'block_content:homepage_block_2'
-              label: 'Most Requested'
-              provider: 'block_content'
-              label_display: 0
-              view_mode: default
-              context_mapping: {}
-            additional: {  }
-            weight: 2
-          -
-            region: top
-            configuration:
-              id: 'block_content:homepage_block_3'
-              label: 'Focus On'
-              provider: 'block_content'
-              label_display: 0
-              view_mode: default
-              context_mapping: {}
-            additional: {  }
-            weight: 3
-          -
-            region: top
-            configuration:
-              id: 'block_content:homepage_block_4'
-              label: 'Your Government'
-              provider: 'block_content'
-              label_display: 0
-              view_mode: default
-              context_mapping: {}
-            additional: {  }
-            weight: 4
-          -
-            region: bottom
-            configuration:
-              id: 'views_block:blocks-block_2'
-              label: Features
-              label_display: visible
-              view_mode: full
-              weight: 0
-            additional: {  }
-            weight: 0
-    -
-      name: topic
-      title: '[Theme title]'
-      language: en
-      body: |
-        <p>1-2 sentences that describe the topics and top tasks that can be accessed on this page.</p>
-      alias: /topic
-      queue: topic_page
-      metatags:
-        -
-          title: '[node:title]'
-          description: '[node:summary]'
-          keywords: 'Canada.ca, Open Government, Open Government Canada, Canada Open Government, Canada Open'
-      layout:
-        layout_id: 'bs_2col_bricked'
-        layout_settings:
+        sections:
+        - layout_id: 'wxt_homepage'
+          layout_settings:
             layout:
               wrapper: div
-              classes:
-                row: row
+              classes: {}
               add_layout_class: 1
               attributes: ''
             regions:
               top:
                 wrapper: div
-                classes:
-                  col-sm-12: col-sm-12
+                classes: {}
                 add_region_classes: 1
                 attributes: ''
               top_left:
@@ -189,67 +70,188 @@ source:
                   col-sm-12: col-sm-12
                 add_region_classes: 1
                 attributes: class|mrgn-tp-lg
-        components:
-          -
-            region: top_left
-            configuration:
-              id: 'page_title_block'
-              label: 'Page title'
-              provider: core
-              label_display: 0
-              context_mapping: {}
-            additional: {  }
-            weight: 0
-          -
-            region: top_right
-            configuration:
-              id: 'entity_block:653x194'
-              label: 'Media'
-              provider: entity_block
-              label_display: 0
-              view_mode: default
-              context_mapping: {}
-            additional: {  }
-            weight: 1
-          -
-            region: top_left
-            configuration:
-              id: local_tasks_block
-              label: Tabs
-              provider: core
-              label_display: 0
-              primary: 1
-              secondary: 1
-              context_mapping: {}
-            additional: {  }
-            weight: 1
-          -
-            region: top_left
-            configuration:
-              id: 'field_block:node:landing_page:body'
-              label: Body
-              provider: layout_builder
-              label_display: 0
-              formatter:
-                label: hidden
-                type: text_default
-                settings: {  }
-                third_party_settings: {  }
+          components:
+            -
+              region: top
+              configuration:
+                id: 'block_content:homepage_block_1'
+                label: Canada
+                provider: 'block_content'
+                label_display: 0
+                view_mode: default
+                context_mapping: {}
+              additional: {  }
+              weight: 1
+            -
+              region: top
+              configuration:
+                id: 'block_content:homepage_block_2'
+                label: 'Most Requested'
+                provider: 'block_content'
+                label_display: 0
+                view_mode: default
+                context_mapping: {}
+              additional: {  }
+              weight: 2
+            -
+              region: top
+              configuration:
+                id: 'block_content:homepage_block_3'
+                label: 'Focus On'
+                provider: 'block_content'
+                label_display: 0
+                view_mode: default
+                context_mapping: {}
+              additional: {  }
+              weight: 3
+            -
+              region: top
+              configuration:
+                id: 'block_content:homepage_block_4'
+                label: 'Your Government'
+                provider: 'block_content'
+                label_display: 0
+                view_mode: default
+                context_mapping: {}
+              additional: {  }
+              weight: 4
+            -
+              region: bottom
+              configuration:
+                id: 'views_block:blocks-block_2'
+                label: Features
+                label_display: visible
+                view_mode: full
                 weight: 0
-              context_mapping:
-                entity: layout_builder.entity
-                view_mode: view_mode
-            additional: {  }
-            weight: 1
-          -
-            region: bottom
-            configuration:
-              id: 'views_block:blocks-block_1'
-              label: Features
-              label_display: visible
-              view_mode: full
-            additional: {  }
-            weight: 1
+              additional: {  }
+              weight: 0
+    -
+      name: topic
+      title: '[Theme title]'
+      language: en
+      body: |
+        <p>1-2 sentences that describe the topics and top tasks that can be accessed on this page.</p>
+      alias: /topic
+      queue: topic_page
+      metatags:
+        -
+          title: '[node:title]'
+          description: '[node:summary]'
+          keywords: 'Canada.ca, Open Government, Open Government Canada, Canada Open Government, Canada Open'
+      layout:
+        sections:
+        - layout_id: 'bs_2col_bricked'
+          layout_settings:
+              layout:
+                wrapper: div
+                classes:
+                  row: row
+                add_layout_class: 1
+                attributes: ''
+              regions:
+                top:
+                  wrapper: div
+                  classes:
+                    col-sm-12: col-sm-12
+                  add_region_classes: 1
+                  attributes: ''
+                top_left:
+                  wrapper: div
+                  classes:
+                    col-md-6: col-md-8
+                  add_region_classes: 1
+                  attributes: class|mrgn-tp-md
+                top_right:
+                  wrapper: div
+                  classes:
+                    col-md-6: col-md-4
+                  add_region_classes: 1
+                  attributes: class|mrgn-tp-xl
+                middle:
+                  wrapper: div
+                  classes:
+                    col-sm-12: col-sm-12
+                  add_region_classes: 1
+                  attributes: ''
+                bottom_left:
+                  wrapper: div
+                  classes:
+                    col-sm-6: col-sm-6
+                  add_region_classes: 1
+                  attributes: ''
+                bottom_right:
+                  wrapper: div
+                  classes:
+                    col-sm-6: col-sm-6
+                  add_region_classes: 1
+                  attributes: ''
+                bottom:
+                  wrapper: div
+                  classes:
+                    col-sm-12: col-sm-12
+                  add_region_classes: 1
+                  attributes: class|mrgn-tp-lg
+          components:
+            -
+              region: top_left
+              configuration:
+                id: 'page_title_block'
+                label: 'Page title'
+                provider: core
+                label_display: 0
+                context_mapping: {}
+              additional: {  }
+              weight: 0
+            -
+              region: top_right
+              configuration:
+                id: 'entity_block:653x194'
+                label: 'Media'
+                provider: entity_block
+                label_display: 0
+                view_mode: default
+                context_mapping: {}
+              additional: {  }
+              weight: 1
+            -
+              region: top_left
+              configuration:
+                id: local_tasks_block
+                label: Tabs
+                provider: core
+                label_display: 0
+                primary: 1
+                secondary: 1
+                context_mapping: {}
+              additional: {  }
+              weight: 1
+            -
+              region: top_left
+              configuration:
+                id: 'field_block:node:landing_page:body'
+                label: Body
+                provider: layout_builder
+                label_display: 0
+                formatter:
+                  label: hidden
+                  type: text_default
+                  settings: {  }
+                  third_party_settings: {  }
+                  weight: 0
+                context_mapping:
+                  entity: layout_builder.entity
+                  view_mode: view_mode
+              additional: {  }
+              weight: 1
+            -
+              region: bottom
+              configuration:
+                id: 'views_block:blocks-block_1'
+                label: Features
+                label_display: visible
+                view_mode: full
+              additional: {  }
+              weight: 1
   ids:
     name:
       type: string

--- a/modules/custom/wxt_ext/wxt_ext_migration/config/install/migrate_plus.migration.gcweb_node_landing_page_translation.yml
+++ b/modules/custom/wxt_ext/wxt_ext_migration/config/install/migrate_plus.migration.gcweb_node_landing_page_translation.yml
@@ -20,110 +20,111 @@ source:
           description: '[node:summary]'
           keywords: 'Canada.ca, Open Government, Open Government Canada, Canada Open Government, Canada Open'
       layout:
-        layout_id: 'wxt_homepage'
-        layout_settings:
-          layout:
-            wrapper: div
-            classes: {}
-            add_layout_class: 1
-            attributes: ''
-          regions:
-            top:
+        sections:
+        - layout_id: 'wxt_homepage'
+          layout_settings:
+            layout:
               wrapper: div
               classes: {}
-              add_region_classes: 1
+              add_layout_class: 1
               attributes: ''
-            top_left:
-              wrapper: div
-              classes:
-                col-md-6: col-md-8
-              add_region_classes: 1
-              attributes: class|mrgn-tp-md
-            top_right:
-              wrapper: div
-              classes:
-                col-md-6: col-md-4
-              add_region_classes: 1
-              attributes: class|mrgn-tp-xl
-            middle:
-              wrapper: div
-              classes:
-                col-sm-12: col-sm-12
-              add_region_classes: 1
-              attributes: ''
-            bottom_left:
-              wrapper: div
-              classes:
-                col-sm-6: col-sm-6
-              add_region_classes: 1
-              attributes: ''
-            bottom_right:
-              wrapper: div
-              classes:
-                col-sm-6: col-sm-6
-              add_region_classes: 1
-              attributes: ''
-            bottom:
-              wrapper: div
-              classes:
-                col-sm-12: col-sm-12
-              add_region_classes: 1
-              attributes: class|mrgn-tp-lg
-        components:
-          -
-            region: top
-            configuration:
-              id: 'block_content:homepage_block_1'
-              label: Canada
-              provider: 'block_content'
-              label_display: 0
-              view_mode: default
-              context_mapping: {}
-            additional: {  }
-            weight: 1
-          -
-            region: top
-            configuration:
-              id: 'block_content:homepage_block_2'
-              label: 'En demande'
-              provider: 'block_content'
-              label_display: 0
-              view_mode: default
-              context_mapping: {}
-            additional: {  }
-            weight: 2
-          -
-            region: top
-            configuration:
-              id: 'block_content:homepage_block_3'
-              label: 'Par public'
-              provider: 'block_content'
-              label_display: 0
-              view_mode: default
-              context_mapping: {}
-            additional: {  }
-            weight: 3
-          -
-            region: top
-            configuration:
-              id: 'block_content:homepage_block_4'
-              label: 'Votre gouvernement'
-              provider: 'block_content'
-              label_display: 0
-              view_mode: default
-              context_mapping: {}
-            additional: {  }
-            weight: 4
-          -
-            region: bottom
-            configuration:
-              id: 'views_block:blocks-block_2'
-              label: En Vedette
-              label_display: visible
-              view_mode: full
+            regions:
+              top:
+                wrapper: div
+                classes: {}
+                add_region_classes: 1
+                attributes: ''
+              top_left:
+                wrapper: div
+                classes:
+                  col-md-6: col-md-8
+                add_region_classes: 1
+                attributes: class|mrgn-tp-md
+              top_right:
+                wrapper: div
+                classes:
+                  col-md-6: col-md-4
+                add_region_classes: 1
+                attributes: class|mrgn-tp-xl
+              middle:
+                wrapper: div
+                classes:
+                  col-sm-12: col-sm-12
+                add_region_classes: 1
+                attributes: ''
+              bottom_left:
+                wrapper: div
+                classes:
+                  col-sm-6: col-sm-6
+                add_region_classes: 1
+                attributes: ''
+              bottom_right:
+                wrapper: div
+                classes:
+                  col-sm-6: col-sm-6
+                add_region_classes: 1
+                attributes: ''
+              bottom:
+                wrapper: div
+                classes:
+                  col-sm-12: col-sm-12
+                add_region_classes: 1
+                attributes: class|mrgn-tp-lg
+          components:
+            -
+              region: top
+              configuration:
+                id: 'block_content:homepage_block_1'
+                label: Canada
+                provider: 'block_content'
+                label_display: 0
+                view_mode: default
+                context_mapping: {}
+              additional: {  }
+              weight: 1
+            -
+              region: top
+              configuration:
+                id: 'block_content:homepage_block_2'
+                label: 'En demande'
+                provider: 'block_content'
+                label_display: 0
+                view_mode: default
+                context_mapping: {}
+              additional: {  }
+              weight: 2
+            -
+              region: top
+              configuration:
+                id: 'block_content:homepage_block_3'
+                label: 'Par public'
+                provider: 'block_content'
+                label_display: 0
+                view_mode: default
+                context_mapping: {}
+              additional: {  }
+              weight: 3
+            -
+              region: top
+              configuration:
+                id: 'block_content:homepage_block_4'
+                label: 'Votre gouvernement'
+                provider: 'block_content'
+                label_display: 0
+                view_mode: default
+                context_mapping: {}
+              additional: {  }
+              weight: 4
+            -
+              region: bottom
+              configuration:
+                id: 'views_block:blocks-block_2'
+                label: En Vedette
+                label_display: visible
+                view_mode: full
+                weight: 0
+              additional: {  }
               weight: 0
-            additional: {  }
-            weight: 0
     -
       name: topic
       title: '[Titre du thème]'
@@ -138,8 +139,9 @@ source:
           description: '[node:summary]'
           keywords: 'Canada.ca, Open Government, Open Government Canada, Canada Open Government, Canada Open'
       layout:
-        layout_id: 'bs_2col_bricked'
-        layout_settings:
+        sections:
+        - layout_id: 'bs_2col_bricked'
+          layout_settings:
             layout:
               wrapper: div
               classes:

--- a/modules/custom/wxt_ext/wxt_ext_migration/src/Plugin/migrate/process/LayoutPluginId.php
+++ b/modules/custom/wxt_ext/wxt_ext_migration/src/Plugin/migrate/process/LayoutPluginId.php
@@ -125,7 +125,7 @@ class LayoutPluginId extends ProcessPluginBase implements ContainerFactoryPlugin
       $section = new Section($section_value['layout_id'], $section_value['layout_settings']);
       $sections[] = $section;
       foreach ($section_value['components'] as $tmp_component) {
-        list($module, $delta) = explode(":", $tmp_component['configuration']['id'], 2);
+        list($module, $delta) = array_pad(explode(":", $tmp_component['configuration']['id'], 2), 2, NULL);
         switch ($module) {
           case 'block_content':
             $block_id = $this->migrationPlugin


### PR DESCRIPTION
This MR adds the ability to define multiple sections in a layout page using the `wxt_layout_plugin_id` migration.

**IMPORTANT NOTE**: This changes the expected data structure and therefore is a breaking change. I have added documentation to the release notes for this.