### PR TITLE
Update 8433 breaks your site if media modules are not enabled

### DIFF
--- a/modules/custom/wxt_core/wxt_core.install
+++ b/modules/custom/wxt_core/wxt_core.install
@@ -345,6 +345,11 @@ function wxt_core_update_8431() {
  * Updates for the WxT 4.3.3 release.
  */
 function wxt_core_update_8433() {
+  // Don't run if the site isn't using media.
+  $module_handler = \Drupal::service('module_handler');
+  if (!$module_handler->moduleExists('lightning_media') && !$module_handler->moduleExists('wxt_ext_media')) {
+    return;
+  }
 
   // Retrieve the config factory.
   $config_factory = \Drupal::configFactory();


### PR DESCRIPTION
If you run wxt_core update 8433 without lightning_media or wxt_ext_media installed, some configuration gets created that breaks the site.

The issue is that `field.storage.block_content.field_slideshow_items` is installed, but since the modules aren't enabled, the field plugins aren't there, which causes the following error on bootstrap:
```
 [error]  Error: Call to a member function getThirdPartySetting() on null in Drupal\content_translation\ContentTranslationManager->getBundleTranslationSettings() (line 122 of /home/dpascoed/workspace/statcan/sdr-project/site-stc-sdr/html/core/modules/content_translation/src/ContentTranslationManager.php) #0 /home/dpascoed/workspace/statcan/sdr-project/site-stc-sdr/html/core/modules/content_translation/content_translation.module(254): Drupal\content_translation\ContentTranslationManager->getBundleTranslationSettings()
```

My fix is to first check that at least one of either lightning_media or wxt_ext_media is being used before running the update hook.