### PR TITLE
Fixing issues with image uploading due to the deprecated "file_create_url()" function

### DIFF
--- a/modules/custom/wxt_core/src/Plugin/Field/FieldFormatter/Lightbox.php
+++ b/modules/custom/wxt_core/src/Plugin/Field/FieldFormatter/Lightbox.php
@@ -106,7 +106,7 @@ class Lightbox extends ImageFormatterBase {
           'title' => $title,
         ],
       ];
-      $url = Url::fromUri(file_create_url($lbx_image_path), $url_options);
+      $url = Url::fromUri(\Drupal::service('file_url_generator')->generateAbsoluteString($lbx_image_path), $url_options);
 
       $item_attributes['class'][] = 'thumbnail';
 


### PR DESCRIPTION
Good morning, DrupalWxT team!

I noticed some issues with our production sites while we're testing out the latest 5.0.x release stream. We can't seem to upload images using our existing content types and the image uploader due to the presence of a deprecated function in the Lightbox.php file. 

I have the proposed fix below and it's fixed the issue on our sites.
