### PR TITLE
Prepare D11 release - replace override modules with contrib.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "cweagans/composer-patches": "^1.7",
         "drupal/admin_toolbar": "^3.5",
         "drupal/autosave_form": "^1.7",
-        "drupal/block_class": "^4.0",
+        "drupal/block_class": "^4.0.1",
         "drupal/blog": "^3.1",
         "drupal/book": "^2.0",
         "drupal/bootstrap_layouts": "^5.4",
@@ -47,7 +47,7 @@
         "drupal/image_widget_crop": "2.x-dev@dev",
         "drupal/inline_entity_form": "^3.0@RC",
         "drupal/layout_builder_restrictions": "^3.0",
-        "drupaloverride/layout_builder_st": "dev-master",
+        "drupal/layout_builder_st": "dev-2.0.x#68f690c8",
         "drupal/layout_builder_styles": "^2.1",
         "drupal/layout_library": "^1.0@beta",
         "drupal/linkit": "^7.0",
@@ -69,7 +69,7 @@
         "drupal/search_api": "^1.37",
         "drupal/simple_sitemap": "^4.2",
         "drupal/slick_entityreference": "^3.0",
-        "drupaloverride/toc_api": "dev-master",
+        "drupal/toc_api": "^2.0",
         "drupal/toc_filter": "^2.3",
         "drupal/token": "^1.15",
         "drupal/token_filter": "^2.2",
@@ -96,9 +96,6 @@
         "oomphinc/composer-installers-extender": "^1.1 || ^2",
         "squizlabs/php_codesniffer": "3.*",
         "phpspec/prophecy-phpunit": "^2"
-    },
-    "replace": {
-        "drupal/toc_api": "*"
     },
     "config": {
         "discard-changes": true,
@@ -145,32 +142,6 @@
                 "dist": {
                     "url": "https://use.fontawesome.com/releases/v6.4.2/fontawesome-free-6.4.2-web.zip",
                     "type": "zip"
-                }
-            }
-        },
-        {
-            "type": "package",
-            "package": {
-                "name": "drupaloverride/layout_builder_st",
-                "version": "dev-master",
-                "type": "drupal-module",
-                "source": {
-                    "url": "https://git.drupalcode.org/issue/layout_builder_st-3431600.git",
-                    "type": "git",
-                    "reference": "3431600-automated-drupal-11"
-                }
-            }
-        },
-        {
-            "type": "package",
-            "package": {
-                "name": "drupaloverride/toc_api",
-                "version": "dev-master",
-                "type": "drupal-module",
-                "source": {
-                    "url": "https://git.drupalcode.org/issue/toc_api-3455312.git",
-                    "type": "git",
-                    "reference": "3455312-drupal11-fixes"
                 }
             }
         }
@@ -281,8 +252,6 @@
                 "https://www.drupal.org/files/issues/2022-11-02/2817109-2.0.x-how-to-redirect-30.patch"
             },
             "drupal/layout_builder_st": {
-                "3420063 - Call to a member function getConfig() OverridesSectionStorage.php":
-                "https://git.drupalcode.org/project/layout_builder_st/-/merge_requests/6.diff",
                 "3411037 - Fix core removing contextual translation links":
                 "https://git.drupalcode.org/project/layout_builder_st/-/merge_requests/5.patch"
             },
@@ -303,6 +272,10 @@
             "drupal/redis": {
                 "3004561 - Enable ssl scheme":
                 "https://www.drupal.org/files/issues/2021-11-19/redis-support_tls_on_predis-3004561-37.patch"
+            },
+            "drupal/toc_filter": {
+                "3518549 and 3520464 - toc_filter D11 bug fix":
+                "https://www.drupal.org/files/issues/2025-04-24/toc-filter-3518549-13.patch"
             },
             "drupal/webform": {
                 "Enter drupal/webform patch #3205860 description here":


### PR DESCRIPTION
Bump up block_class to ^4.0.1 due to security advisory yesterday add toc_filter patch to fix reported issue with D11 replace override for layout_builder_st , pin to 2.0.x dev hash replace override for toc_api with latest tagged release for D11