### PR TITLE
Unlock layout_builder_st from 2.0.x#hash since composer acts weird fi…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
         "drupal/image_widget_crop": "2.x-dev@dev",
         "drupal/inline_entity_form": "^3.0@RC",
         "drupal/layout_builder_restrictions": "^3.0",
-        "drupal/layout_builder_st": "dev-2.0.x#68f690c8",
+        "drupal/layout_builder_st": "dev-2.0.x",
         "drupal/layout_builder_styles": "^2.1",
         "drupal/layout_library": "^1.0@beta",
         "drupal/linkit": "^7.0",


### PR DESCRIPTION
…guring out upstream changes to patches when this is locked.

Locking with 2.0.x-dev#hashcode affects composers ability to resolve upstream changes to patches.  Unlock due to composer 2.8.5 difficulties.