### PR TITLE
Enable WET-BOEW inline form validation for webforms

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,9 +7,14 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@master
+
+    - name: Setup PHP 8.3
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: '8.3'
 
     - name: Setup dependencies
       run: |

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -22,9 +22,8 @@ jobs:
         cd site-wxt
         rm composer.lock
 
-    - uses: statcan/actions/composer@master
-      with:
-        args: require ${{ github.event.pull_request.head.repo.full_name }}:dev-${{ github.event.pull_request.head.ref }}#${{ github.event.pull_request.head.sha }} --working-dir=./site-wxt
+    - name: Require patched wxt with Composer
+      run: composer require "${{ github.event.pull_request.head.repo.full_name }}:dev-${{ github.event.pull_request.head.ref }}#${{ github.event.pull_request.head.sha }}" --working-dir=./site-wxt
 
     - name: Build out the Drupal infrastructure
       run: |

--- a/composer.json
+++ b/composer.json
@@ -249,10 +249,6 @@
                 "Enter drupal/group patch #2817109 description here":
                 "https://www.drupal.org/files/issues/2022-11-02/2817109-2.0.x-how-to-redirect-30.patch"
             },
-            "drupal/layout_builder_st": {
-                "3420063 - Call to a member function getConfig() OverridesSectionStorage.php":
-                "https://git.drupalcode.org/project/layout_builder_st/-/merge_requests/6.diff"
-            },
             "drupal/page_manager": {
                 "Enter drupal/page_manager patch #2626090 description here":
                 "https://www.drupal.org/files/issues/page-manager-2626090-page-title-empty-5.patch",

--- a/composer.json
+++ b/composer.json
@@ -217,7 +217,7 @@
                 "2938129 - PageTitle block is non-functional when not handled directly by BlockPageVariant":
                 "https://www.drupal.org/files/issues/2025-01-28/drupal-PageTitle_block-2938129-43.patch",
                 "3500238 - Rename tests to fix core phpunit kernel tests":
-                "https://www.drupal.org/files/issues/2025-08-20/3500238-core-11.1.8.patch"
+                "https://www.drupal.org/files/issues/2025-08-20/3500238-core-11.1.8--16.patch"
             },
             "drupal/ctools": {
                 "Enter drupal/ctools patch #2667652 description here":

--- a/composer.json
+++ b/composer.json
@@ -280,10 +280,6 @@
             "drupal/ckeditor_details": {
                 "3244311 - Allow <details> element to be placed without <div>":
                 "https://www.drupal.org/files/issues/2024-11-15/3244311-9.patch"
-            },
-            "drupal/linkit": {
-                "3078075 - Detect and strip base URL from pasted URLs":
-                "https://www.drupal.org/files/issues/2025-07-02/linkit-detect-strip-base-url-3078075-118.patch"
             }
         }
     },

--- a/composer.json
+++ b/composer.json
@@ -65,7 +65,7 @@
         "drupal/password_policy": "^4.0",
         "drupal/pathauto": "^1.13",
         "drupal/redirect": "^1.10",
-        "drupal/redis": "^1.8",
+        "drupal/redis": "^1.10",
         "drupal/search_api": "^1.37",
         "drupal/simple_sitemap": "^4.2",
         "drupal/slick_entityreference": "^3.0",

--- a/composer.json
+++ b/composer.json
@@ -251,9 +251,7 @@
             },
             "drupal/layout_builder_st": {
                 "3420063 - Call to a member function getConfig() OverridesSectionStorage.php":
-                "https://git.drupalcode.org/project/layout_builder_st/-/merge_requests/6.diff",
-                "3411037 - Fix core removing contextual translation links":
-                "https://git.drupalcode.org/project/layout_builder_st/-/merge_requests/5.patch"
+                "https://git.drupalcode.org/project/layout_builder_st/-/merge_requests/6.diff"
             },
             "drupal/page_manager": {
                 "Enter drupal/page_manager patch #2626090 description here":

--- a/composer.json
+++ b/composer.json
@@ -271,7 +271,7 @@
             },
             "drupal/redis": {
                 "3004561 - Enable ssl scheme":
-                "https://www.drupal.org/files/issues/2021-11-19/redis-support_tls_on_predis-3004561-37.patch"
+                "https://www.drupal.org/files/issues/2025-08-13/redis-support_tls_on_predis-3004561-49.patch"
             },
             "drupal/webform": {
                 "Enter drupal/webform patch #3205860 description here":

--- a/composer.json
+++ b/composer.json
@@ -215,7 +215,9 @@
                 "3359497 - Prevent warnings when library definitions have a license with no URL defined, contrib is not perfect here.":
                 "https://www.drupal.org/files/issues/2023-10-07/fix-license-missing-url.patch",
                 "2938129 - PageTitle block is non-functional when not handled directly by BlockPageVariant":
-                "https://www.drupal.org/files/issues/2025-01-28/drupal-PageTitle_block-2938129-43.patch"
+                "https://www.drupal.org/files/issues/2025-01-28/drupal-PageTitle_block-2938129-43.patch",
+                "3500238 - Rename tests to fix core phpunit kernel tests":
+                "https://www.drupal.org/files/issues/2025-08-20/3500238-core-11.1.8.patch"
             },
             "drupal/ctools": {
                 "Enter drupal/ctools patch #2667652 description here":

--- a/modules/custom/wxt_ext/wxt_ext_webform/wxt_ext_webform.module
+++ b/modules/custom/wxt_ext/wxt_ext_webform/wxt_ext_webform.module
@@ -11,6 +11,8 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Link;
 use Drupal\webform\Entity\Webform;
 use Drupal\webform\Entity\WebformSubmission;
+use Drupal\webform\Utility\WebformArrayHelper;
+use Drupal\webform\Utility\WebformElementHelper;
 
 /**
  * Implements hook_theme().
@@ -54,6 +56,21 @@ function wxt_ext_webform_webform_third_party_settings_form_alter(array &$form, F
     '#parents' => ['third_party_settings', 'wxt_ext_webform', 'wet_inline_validation'],
     '#weight' => 99,
   ];
+}
+
+/**
+ * Implements hook__preprocess_form_element().
+ */
+function wxt_ext_webform_preprocess_form_element(array &$variables) {
+  // Only perform this action on webform elements.
+  if (!WebformElementHelper::isWebformElement($variables['element'])) {
+    return;
+  }
+
+  // Remove form-inline class for element wrappers to ensure proper rendering with label.
+  if (!empty($variables['attributes']['class'])) {
+    WebformArrayHelper::removeValue($variables['attributes']['class'], 'form-inline');
+  }
 }
 
 /**

--- a/modules/custom/wxt_ext/wxt_ext_webform/wxt_ext_webform.module
+++ b/modules/custom/wxt_ext/wxt_ext_webform/wxt_ext_webform.module
@@ -9,10 +9,12 @@ use Drupal\Core\Ajax\AjaxResponse;
 use Drupal\Core\Ajax\HtmlCommand;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Link;
+use Drupal\Core\Render\Markup;
 use Drupal\webform\Entity\Webform;
 use Drupal\webform\Entity\WebformSubmission;
 use Drupal\webform\Utility\WebformArrayHelper;
 use Drupal\webform\Utility\WebformElementHelper;
+use Drupal\webform\WebformInterface;
 
 /**
  * Implements hook_theme().
@@ -30,6 +32,30 @@ function wxt_ext_webform_theme($existing, $type, $theme, $path) {
       ],
     ],
   ];
+}
+
+/**
+ * Implements hook_form_FORM_ID_alter() for webform_edit_form.
+ */
+function wxt_ext_webform_form_webform_edit_form_alter(array &$form, FormStateInterface $form_state, $form_id): void {
+  // Get the Webform entity from the form.
+  $form_object = $form_state->getFormObject();
+  if (!method_exists($form_object, 'getEntity')) {
+    return;
+  }
+  $webform = $form_object->getEntity();
+  if (!$webform instanceof WebformInterface) {
+    return;
+  }
+
+  $enabled = (bool) $webform->getThirdPartySetting('wxt_ext_webform', 'wet_inline_validation', FALSE);
+
+  if ($enabled) {
+    \Drupal::messenger()->addStatus(t('WET-BOEW inline validation is <strong>ENABLED</strong> for this webform. To add special validation to a field, edit the field, go to the Advanced tab -> Element attributes -> Element custom attributes (YAML) and add custom attributes as per <a href="https://wet-boew.github.io/wet-boew/docs/ref/formvalid/formvalid-en.html#SpecializedValidation">https://wet-boew.github.io/wet-boew/docs/ref/formvalid/formvalid-en.html#SpecializedValidation</a>'));
+  }
+  else {
+    \Drupal::messenger()->addWarning(t('WET-BOEW inline validation is <strong>DISABLED</strong> for this webform. To enable it, go to the Settings tab and select the "Enable WET-BOEW inline validation" option.'));
+  }
 }
 
 /**
@@ -59,7 +85,7 @@ function wxt_ext_webform_webform_third_party_settings_form_alter(array &$form, F
 }
 
 /**
- * Implements hook__preprocess_form_element().
+ * Implements hook_preprocess_form_element().
  */
 function wxt_ext_webform_preprocess_form_element(array &$variables) {
   // Only perform this action on webform elements.

--- a/modules/custom/wxt_ext/wxt_ext_webform/wxt_ext_webform.module
+++ b/modules/custom/wxt_ext/wxt_ext_webform/wxt_ext_webform.module
@@ -31,6 +31,32 @@ function wxt_ext_webform_theme($existing, $type, $theme, $path) {
 }
 
 /**
+ * Implements hook_webform_third_party_settings_form_alter().
+ */
+function wxt_ext_webform_webform_third_party_settings_form_alter(array &$form, FormStateInterface $form_state) {
+  // Get the Webform entity being edited.
+  $form_object = $form_state->getFormObject();
+  $webform = $form_object->getEntity();
+
+  $form['form']['wxt_settings'] = [
+    '#type' => 'details',
+    '#title' => t('WxT settings'),
+    '#open' => TRUE,
+  ];
+
+  // Add the checkbox and store under third_party_settings.
+  $form['form']['wxt_settings']['wxt_inline_validation'] = [
+    '#type' => 'checkbox',
+    '#title' => t('Enable WET-BOEW inline validation'),
+    '#description' => t('Enable WET-BOEW inline form validation for this webform. When enabled, the form will be wrapped in a <code>&lt;div class="wb-frmvld"&gt;</code> container so WET-BOEW can apply its built-in client-side validation, displaying error messages inline as users complete the form.'),
+    '#default_value' => $webform->getThirdPartySetting('wxt_ext_webform', 'wet_inline_validation', FALSE),
+    // Make it land in $form_state values under third_party_settings.
+    '#parents' => ['third_party_settings', 'wxt_ext_webform', 'wet_inline_validation'],
+    '#weight' => 99,
+  ];
+}
+
+/**
  * Implements hook_theme_suggestions_HOOK_alter().
  */
 function wxt_ext_webform_theme_suggestions_form_element_alter(array &$suggestions, array $variables) {
@@ -87,6 +113,16 @@ function wxt_ext_webform_webform_submission_form_alter(array &$form, FormStateIn
         ],
       ];
     }
+  }
+
+  // Get the Webform entity being edited.
+  $form_object = $form_state->getFormObject();
+  $webform_submission = $form_object->getEntity();
+  $webform = $webform_submission->getWebform();
+
+  if ($webform->getThirdPartySetting('wxt_ext_webform', 'wet_inline_validation', FALSE)) {
+    $form['#prefix'] = ($form['#prefix'] ?? '') . '<div class="wb-frmvld">';
+    $form['#suffix'] = '</div>' . ($form['#suffix'] ?? '');
   }
 }
 

--- a/modules/custom/wxt_ext/wxt_ext_webform/wxt_ext_webform.module
+++ b/modules/custom/wxt_ext/wxt_ext_webform/wxt_ext_webform.module
@@ -9,7 +9,6 @@ use Drupal\Core\Ajax\AjaxResponse;
 use Drupal\Core\Ajax\HtmlCommand;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Link;
-use Drupal\Core\Render\Markup;
 use Drupal\webform\Entity\Webform;
 use Drupal\webform\Entity\WebformSubmission;
 use Drupal\webform\Utility\WebformArrayHelper;


### PR DESCRIPTION
Add third-party setting to webforms for WET-BOEW inline form validation, wrap webform in wb-frmvdl class if setting is enabled